### PR TITLE
aws-credentials.py: Add AWS_REGION environment variable

### DIFF
--- a/aws-credentials.py
+++ b/aws-credentials.py
@@ -156,8 +156,10 @@ with open(fn, 'a') as f:
 #  tmptoken.sh' and it will automatically find it.
 tmptoken = Options.HomeDir + "/bin/tmptoken.sh"
 with open(tmptoken, 'w') as f:
-    f.write("# Last Modified: "+ time.strftime("%d/%m/%Y %H:%M:%S")+"'\n")
+    f.write("# Last Modified: "+ time.strftime("%d/%m/%Y %H:%M:%S")+"\n")
+    # f.write("# export AWS_DEFAULT_PROFILE='"+Options.NewProfile+"'\n")
+    # f.write("# export AWS_DEFAULT_REGION='"+Options.NewProfile+"'\n")
+    f.write("export AWS_REGION=$AWS_DEFAULT_REGION\n")
     f.write("export AWS_ACCESS_KEY_ID='"+Credentials.Access+"'\n")
     f.write("export AWS_SECRET_ACCESS_KEY='"+Credentials.Secret+"'\n")
     f.write("export AWS_SESSION_TOKEN='"+Credentials.Token+"'\n")
-    f.write("# export AWS_DEFAULT_PROFILE='"+Options.NewProfile+"'\n")

--- a/aws-credentials.py
+++ b/aws-credentials.py
@@ -158,8 +158,8 @@ tmptoken = Options.HomeDir + "/bin/tmptoken.sh"
 with open(tmptoken, 'w') as f:
     f.write("# Last Modified: "+ time.strftime("%d/%m/%Y %H:%M:%S")+"\n")
     # f.write("# export AWS_DEFAULT_PROFILE='"+Options.NewProfile+"'\n")
-    # f.write("# export AWS_DEFAULT_REGION='"+Options.NewProfile+"'\n")
-    f.write("export AWS_REGION=$AWS_DEFAULT_REGION\n")
+    f.write("export AWS_DEFAULT_REGION='"+Options.Region+"'\n")
+    f.write("export AWS_REGION='"+Options.Region+"'\n")
     f.write("export AWS_ACCESS_KEY_ID='"+Credentials.Access+"'\n")
     f.write("export AWS_SECRET_ACCESS_KEY='"+Credentials.Secret+"'\n")
     f.write("export AWS_SESSION_TOKEN='"+Credentials.Token+"'\n")

--- a/config.ini.example
+++ b/config.ini.example
@@ -1,6 +1,7 @@
 HomeDir = "<YourHomeDirectory>"
 NewProfile = "<NameOfTheNewProfile>"
 IamUserArn = "arn:aws:iam::XXXXXXXXXXXXX:mfa/user.name"
+Region     = "ap-southeast-2"
 
 # Role To Assume
-IamRoleArn = "arn:aws:iam::XXXXXXXXXXXX:role/RolName"
+IamRoleArn = "arn:aws:iam::XXXXXXXXXXXX:role/RoleName"


### PR DESCRIPTION
AWS_REGION will be set to the value of AWS_DEFAULT_REGION. Some Ansible
modules respect AWS_REGION instead of AWS_DEFAULT_REGION.

Also fixed a minor aesthetic typo in the Last Modified string.